### PR TITLE
#12 Direct call of docker-compose is deprecated

### DIFF
--- a/docs/src/docker-compose.md
+++ b/docs/src/docker-compose.md
@@ -22,20 +22,23 @@ git clone https://github.com/it-at-m/dave-frontend
 git checkout sprint
 ```
 
-2. Install Docker and Docker Compose: You need to have Docker and Docker Compose installed on your system. If you don't have them installed, you can follow the official documentation to install them. You can use the following commands to check if they are installed:
+2. Install Docker and Docker Compose: You need to have Docker and Docker Compose installed on your system. 
+If you don't have them installed, you can follow the official documentation to install them. 
+You can use the following commands to check if they are installed:
 ```
 docker --version
-docker-compose --version
+docker compose --version
 ```
+As an alternative to Docker, [Podman](https://podman.io/) can also be used.
 
 3. Build the images: Next, you need to build the Docker images by navigating to dave-frontend-github/stack directory and running the following command in the terminal:
 ```
-docker-compose build
+docker compose build
 ```
 
 4. Start the containers: After the images are built, you can start the containers by running the following command in the terminal:
 ```
-docker-compose up
+docker compose up
 ```
 
 5. Access the application: Once the containers are up and running, you can access it by navigating to http://localhost:8082 in your web browser.

--- a/docs/src/docker-compose.md
+++ b/docs/src/docker-compose.md
@@ -31,7 +31,7 @@ docker compose --version
 ```
 As an alternative to Docker, [Podman](https://podman.io/) can also be used.
 
-3. Build the images: Next, you need to build the Docker images by navigating to dave-frontend-github/stack directory and running the following command in the terminal:
+3. Build the images: Next, you need to build the Docker images by navigating to dave-frontend/stack directory and running the following command in the terminal:
 ```
 docker compose build
 ```


### PR DESCRIPTION
# Description

<!-- Add a short description of what the request is all about here -->
Docker compose docu adjusted

# Issue References

<!-- Add the corresponding issues here -->
https://github.com/it-at-m/dave/issues/12
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [ ] Acceptance criteria are met
- [ ] Testing is done (unit-tests, DEV-environment)
- [ ] Build/Test workflow has successfully finished
- [ ] Release notes are complemented
- [ ] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Docker Compose setup with reworded steps and split commands for readability.
  * Updated commands to use modern "docker compose" syntax for version check, build, and startup.
  * Added Podman as an alternative container runtime.
  * Improved formatting and command block presentation for easier follow-through.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->