### PR TITLE
FV-361 Bugfix: Verrutschte Elemente bei Export Belastungsplan

### DIFF
--- a/svg/fjs_belastungsplan_inkscape.svg
+++ b/svg/fjs_belastungsplan_inkscape.svg
@@ -536,7 +536,7 @@
          transform="matrix(0.16996929,0,0,0.4104001,81.91578,36.842952)"
          inkscape:label="compass2" />
       <text
-         xml:space="preserve"
+         xml:space="default"
          id="compass1"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24.6944px;font-family:RomanD;-inkscape-font-specification:'RomanD, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:2.2868"
          x="141.28041"
@@ -613,20 +613,20 @@
            inkscape:label="node1_number">
           <circle
              style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.597525;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
-             id="node1_circle"
+             id="node1_number_circle"
              cx="700"
              cy="614.25"
              inkscape:label="circle"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
-             id="node1_circle_text"
+             id="node1_number_text"
              y="622.00684"
              x="693.53955"><tspan
                sodipodi:role="line"
                style="stroke-width:30.9229"
-               id="node1_circle_tspan"
+               id="node1_number_tspan"
                x="693.53955"
                y="622.00684">1</tspan></text>
         </g>
@@ -845,7 +845,7 @@
              inkscape:label="circle"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node2_number_text"
              y="707.33368"
@@ -1063,7 +1063,7 @@
              inkscape:label="circle"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node3_number_text"
              y="792.38141"
@@ -1282,7 +1282,7 @@
              inkscape:label="circle"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node4_number_text"
              y="707.20343"
@@ -1495,7 +1495,7 @@
              inkscape:label="circle"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node5_number_text"
              y="646.03784"
@@ -1725,7 +1725,7 @@
              inkscape:label="circle"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node6_number_text"
              y="1118.2867"
@@ -1947,7 +1947,7 @@
              inkscape:label="circle"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node7_number_text"
              y="767.69238"
@@ -2168,7 +2168,7 @@
              inkscape:label="circle"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node8_number_text"
              y="646.78491"

--- a/svg/fjs_belastungsplan_plain.svg
+++ b/svg/fjs_belastungsplan_plain.svg
@@ -74,7 +74,7 @@
          d="m 399.4343,-24.60083 105.23313,182.26914 -210.46627,-1e-5 z"
          transform="matrix(0.16996929,0,0,0.4104001,81.91578,36.842952)" />
       <text
-         xml:space="preserve"
+         xml:space="default"
          id="compass1"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24.6944px;font-family:RomanD;-inkscape-font-specification:'RomanD, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:2.2868"
          x="141.28041"
@@ -141,18 +141,18 @@
            id="node1_number">
           <circle
              style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.597525;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
-             id="node1_circle"
+             id="node1_number_circle"
              cx="700"
              cy="614.25"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
-             id="node1_circle_text"
+             id="node1_number_text"
              y="622.00684"
              x="693.53955"><tspan
                style="stroke-width:30.9229"
-               id="node1_circle_tspan"
+               id="node1_number_tspan"
                x="693.53955"
                y="622.00684">1</tspan></text>
         </g>
@@ -338,7 +338,7 @@
              cy="700"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node2_number_text"
              y="707.33368"
@@ -518,7 +518,7 @@
              cy="785.75"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node3_number_text"
              y="792.38141"
@@ -699,7 +699,7 @@
              cy="700"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node4_number_text"
              y="707.20343"
@@ -872,7 +872,7 @@
              cy="639.36597"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node5_number_text"
              y="646.03784"
@@ -1066,7 +1066,7 @@
              cy="760.6344"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node6_number_text"
              y="1118.2867"
@@ -1249,7 +1249,7 @@
              cy="760.63751"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node7_number_text"
              y="767.69238"
@@ -1431,7 +1431,7 @@
              cy="639.36597"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node8_number_text"
              y="646.78491"

--- a/svg/qjs_belastungsplan_inkscape.svg
+++ b/svg/qjs_belastungsplan_inkscape.svg
@@ -317,7 +317,7 @@
            transform="matrix(0.16996929,0,0,0.4104001,81.91578,36.842952)"
            inkscape:label="compass2" />
         <text
-           xml:space="preserve"
+           xml:space="default"
            id="compass1"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24.6944px;font-family:RomanD;-inkscape-font-specification:'RomanD, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:2.2868"
            x="141.28348"

--- a/svg/qjs_belastungsplan_plain.svg
+++ b/svg/qjs_belastungsplan_plain.svg
@@ -264,7 +264,7 @@
            d="m 399.4343,-24.60083 105.23313,182.26914 -210.46627,-1e-5 z"
            transform="matrix(0.16996929,0,0,0.4104001,81.91578,36.842952)" />
         <text
-           xml:space="preserve"
+           xml:space="default"
            id="compass1"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24.6944px;font-family:RomanD;-inkscape-font-specification:'RomanD, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:2.2868"
            x="141.28348"

--- a/svg/qu_belastungsplan_inkscape.svg
+++ b/svg/qu_belastungsplan_inkscape.svg
@@ -523,7 +523,7 @@
              inkscape:label="circle"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:28.22049979;stroke-dasharray:none"
              id="node1_circle_text"
              y="622.00684"
@@ -675,7 +675,7 @@
              inkscape:label="circle"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:28.2205;stroke-dasharray:none"
              id="node2_circle_text"
              y="707.33368"
@@ -817,7 +817,7 @@
              inkscape:label="circle"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:28.22049979;stroke-dasharray:none"
              id="node3_circle_text"
              y="792.38141"
@@ -962,7 +962,7 @@
              inkscape:label="circle"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:28.22049979;stroke-dasharray:none"
              id="node4_circle_text"
              y="707.20343"
@@ -1095,7 +1095,7 @@
              inkscape:label="circle"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node5_circle_text"
              y="646.03784"
@@ -1248,7 +1248,7 @@
              inkscape:label="circle"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node6_circle_text"
              y="1118.2867"
@@ -1391,7 +1391,7 @@
              inkscape:label="circle"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node7_circle_text"
              y="767.69238"
@@ -1535,7 +1535,7 @@
              inkscape:label="circle"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node8_circle_text"
              y="646.78491"
@@ -1708,7 +1708,7 @@
          transform="matrix(0.16996929,0,0,0.4104001,81.91578,36.842952)"
          inkscape:label="compass2" />
       <text
-         xml:space="preserve"
+         xml:space="default"
          id="compass1"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24.6944px;font-family:RomanD;-inkscape-font-specification:'RomanD, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:2.2868"
          x="141.28348"

--- a/svg/qu_belastungsplan_plain.svg
+++ b/svg/qu_belastungsplan_plain.svg
@@ -42,7 +42,7 @@
              cy="614.25"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:28.2205;stroke-dasharray:none"
              id="node1_circle_text"
              y="622.00684"
@@ -175,7 +175,7 @@
              cy="700"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:28.2205;stroke-dasharray:none"
              id="node2_circle_text"
              y="707.33368"
@@ -298,7 +298,7 @@
              cy="785.75"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:28.2205;stroke-dasharray:none"
              id="node3_circle_text"
              y="792.38141"
@@ -422,7 +422,7 @@
              cy="700"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:28.2205;stroke-dasharray:none"
              id="node4_circle_text"
              y="707.20343"
@@ -535,7 +535,7 @@
              cy="639.36597"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node5_circle_text"
              y="646.03784"
@@ -669,7 +669,7 @@
              cy="760.6344"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node6_circle_text"
              y="1118.2867"
@@ -792,7 +792,7 @@
              cy="760.63751"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node7_circle_text"
              y="767.69238"
@@ -914,7 +914,7 @@
              cy="639.36597"
              r="11.951238" />
           <text
-             xml:space="preserve"
+             xml:space="default"
              style="font-size:19.7624px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:30.9229"
              id="node8_circle_text"
              y="646.78491"
@@ -1066,7 +1066,7 @@
          d="m 399.4343,-24.60083 105.23313,182.26914 -210.46627,-1e-5 z"
          transform="matrix(0.16996929,0,0,0.4104001,81.91578,36.842952)" />
       <text
-         xml:space="preserve"
+         xml:space="default"
          id="compass1"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24.6944px;font-family:RomanD;-inkscape-font-specification:'RomanD, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:2.2868"
          x="141.28348"


### PR DESCRIPTION
# Description

<!-- Add a short description of what the request is all about here -->
Fixes a bug, where the exported Belastungsplan contained the north arrow (QjS + FjS + Qu) and the node numbers (FjS + Qu) in the wrong position.

# Issue References

<!-- Add the corresponding issues here -->
FV-361
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)