### PR TITLE
Release Notes Sprint 14

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,7 +2,7 @@
 
 ## [Sprint 14] 2026-07-23 - 2026-08-12
 
-* Bugfix: Voreinstellung Block anstatt Tageswert ([FV-481](https://jira.muenchen.de/browse/FV-481))
+* Bugfix: Es wird nun (bis auf Teilzählung Fuss) immer der Tageswert als Vorauswahl in den Filtereinstellungen angezeigt ([FV-481](https://jira.muenchen.de/browse/FV-481), [FV-483](https://jira.muenchen.de/browse/FV-483))
 
 ## [Sprint 13] 2026-07-02 - 2026-07-22
 * Schematische Darstellung beim PDF-Export für die Zählarten QjS, FjS und Qu hinzugefügt ([FV-355](https://jira.muenchen.de/browse/FV-355))

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -3,6 +3,8 @@
 ## [Sprint 14] 2026-07-23 - 2026-08-12
 
 * Bugfix: Es wird nun (bis auf Teilzählung Fuss) immer der Tageswert als Vorauswahl in den Filtereinstellungen angezeigt ([FV-481](https://jira.muenchen.de/browse/FV-481), [FV-483](https://jira.muenchen.de/browse/FV-483))
+* Bugfix: Unterschiedliche Benennungen bei R Sph Block 6-19 Uhr in Listenausgabe ([FV-480](https://jira.muenchen.de/browse/FV-480))
+* Bugfix: Adminportal Bearbeiten Messstelle Abbrechen Button nicht funktional ([FV-493](https://jira.muenchen.de/browse/FV-493))
 * Bugfix: BLP Belastungsbänder zu breit bei QjS im Vergleich zu bestehenden Zählarten ([FV-486](https://jira.muenchen.de/browse/FV-486))
 
 ## [Sprint 13] 2026-07-02 - 2026-07-22

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,7 @@
 * Bugfix: Adminportal Bearbeiten Messstelle Abbrechen Button nicht funktional ([FV-493](https://jira.muenchen.de/browse/FV-493))
 * Bugfix: BLP Belastungsbänder zu breit bei QjS im Vergleich zu bestehenden Zählarten ([FV-486](https://jira.muenchen.de/browse/FV-486))
 * Bugfix: Fehler bei 2x4h Zählung mit Filterauswahl nur SV% und GV% ([FV-427](https://jira.muenchen.de/browse/FV-427))
+* Anpassung der Vorbelegung von Fuss und Rad im Filtermenü für die bestehenden Zählarten ([FV-491](https://jira.muenchen.de/browse/FV-491))
 
 ## [Sprint 13] 2026-07-02 - 2026-07-22
 * Schematische Darstellung beim PDF-Export für die Zählarten QjS, FjS und Qu hinzugefügt ([FV-355](https://jira.muenchen.de/browse/FV-355))

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,9 @@
 # Release-Notes
 
+## [Sprint 14] 2026-07-23 - 2026-08-12
+
+* tbd ([FV-XXX](https://jira.muenchen.de/browse/FV-XXX))
+
 ## [Sprint 13] 2026-07-02 - 2026-07-22
 * Schematische Darstellung beim PDF-Export für die Zählarten QjS, FjS und Qu hinzugefügt ([FV-355](https://jira.muenchen.de/browse/FV-355))
 * Bugfix: Icon und Schriftgröße bei MST (Messstelleninfo) abgeschnitten ([FV-403](https://jira.muenchen.de/browse/FV-403))

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -8,6 +8,7 @@
 * Bugfix: BLP Belastungsbänder zu breit bei QjS im Vergleich zu bestehenden Zählarten ([FV-486](https://jira.muenchen.de/browse/FV-486))
 * Bugfix: Fehler bei 2x4h Zählung mit Filterauswahl nur SV% und GV% ([FV-427](https://jira.muenchen.de/browse/FV-427))
 * Anpassung der Vorbelegung von Fuss und Rad im Filtermenü für die bestehenden Zählarten ([FV-491](https://jira.muenchen.de/browse/FV-491))
+* Verwendung von itm-java-codeformat überprüft und Version im Document-Storage aktualisiert ([FV-193](https://jira.muenchen.de/browse/FV-193))
 
 ## [Sprint 13] 2026-07-02 - 2026-07-22
 * Schematische Darstellung beim PDF-Export für die Zählarten QjS, FjS und Qu hinzugefügt ([FV-355](https://jira.muenchen.de/browse/FV-355))

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -3,6 +3,7 @@
 ## [Sprint 14] 2026-07-23 - 2026-08-12
 
 * Bugfix: Es wird nun (bis auf Teilzählung Fuss) immer der Tageswert als Vorauswahl in den Filtereinstellungen angezeigt ([FV-481](https://jira.muenchen.de/browse/FV-481), [FV-483](https://jira.muenchen.de/browse/FV-483))
+* Bugfix: BLP Belastungsbänder zu breit bei QjS im Vergleich zu bestehenden Zählarten ([FV-486](https://jira.muenchen.de/browse/FV-486))
 
 ## [Sprint 13] 2026-07-02 - 2026-07-22
 * Schematische Darstellung beim PDF-Export für die Zählarten QjS, FjS und Qu hinzugefügt ([FV-355](https://jira.muenchen.de/browse/FV-355))

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,6 +6,7 @@
 * Bugfix: Unterschiedliche Benennungen bei R Sph Block 6-19 Uhr in Listenausgabe ([FV-480](https://jira.muenchen.de/browse/FV-480))
 * Bugfix: Adminportal Bearbeiten Messstelle Abbrechen Button nicht funktional ([FV-493](https://jira.muenchen.de/browse/FV-493))
 * Bugfix: BLP Belastungsbänder zu breit bei QjS im Vergleich zu bestehenden Zählarten ([FV-486](https://jira.muenchen.de/browse/FV-486))
+* Bugfix: Fehler bei 2x4h Zählung mit Filterauswahl nur SV% und GV% ([FV-427](https://jira.muenchen.de/browse/FV-427))
 
 ## [Sprint 13] 2026-07-02 - 2026-07-22
 * Schematische Darstellung beim PDF-Export für die Zählarten QjS, FjS und Qu hinzugefügt ([FV-355](https://jira.muenchen.de/browse/FV-355))

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,7 +2,7 @@
 
 ## [Sprint 14] 2026-07-23 - 2026-08-12
 
-* tbd ([FV-XXX](https://jira.muenchen.de/browse/FV-XXX))
+* Bugfix: Voreinstellung Block anstatt Tageswert ([FV-481](https://jira.muenchen.de/browse/FV-481))
 
 ## [Sprint 13] 2026-07-02 - 2026-07-22
 * Schematische Darstellung beim PDF-Export für die Zählarten QjS, FjS und Qu hinzugefügt ([FV-355](https://jira.muenchen.de/browse/FV-355))


### PR DESCRIPTION
# Description

Release Notes Sprint 14

# Issue References

n/a
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [ ] Testing is done (unit-tests, DEV-environment)
- [ ] Build/Test workflow has successfully finished
- [ ] Release notes are complemented
- [ ] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Filter settings now default to the selected day value, with an exception for Teilzählung Fuß.
  * Corrected an error in the counting filter for 2x4h.
  * Updated default preselection for Fuß and Rad in the filter menu.
  * Fixed an issue with the adminportal cancel button.
  * Adjusted Belastungsbänder width.
  * Corrected naming in a specific “R Sph” time range.
* **Documentation / Maintenance**
  * Updated the related release documentation entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->