### PR TITLE
FV-486 BLP Belastungsbänder zu breit bei QjS im Vergleich zu bestehenden Zählarten

### DIFF
--- a/svg/qjs_belastungsplan_inkscape.svg
+++ b/svg/qjs_belastungsplan_inkscape.svg
@@ -104,14 +104,14 @@
            xml:space="preserve"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.7556px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;white-space:pre;inline-size:268.729;display:inline;fill:#000000;stroke-width:28.2205;stroke-dasharray:none"
            id="zaehlstelle2-multirow"
-             x="1107.07"
+           x="1107.0699"
+           y="84.662277"
+           inkscape:label="zaehlstelle2-multirow"><tspan
+             x="1107.0699"
              y="84.662277"
-             inkscape:label="zaehlstelle2-multirow"><tspan
-               x="1107.07"
-               y="84.662277"
-               id="tspan15">Stadtbezirk 8
+             id="tspan15">Stadtbezirk 8
 </tspan><tspan
-               x="1107.07"
+             x="1107.0699"
              y="109.35677"
                id="tspan16">Zähldatum: 01.01.2026</tspan></text>
       </g>
@@ -251,60 +251,66 @@
            id="arrow1">
           <path
              style="fill:#000000;stroke-width:40.1656"
-             d="m 245,567 v -28 h 909.4546 v 27.998 z"
+             d="m 245 567 v -20 h 909.4546 v 20 z"
              id="arrow1_shaft"
              inkscape:label="shaft1" />
           <path
-             style="fill:none;stroke:#000000;stroke-width:2.08902;stroke-dasharray:none;stroke-opacity:1"
+             style="fill:none;stroke:#000000;stroke-width:1.75545;stroke-dasharray:none;stroke-opacity:1"
              id="arrow1_tip"
-             d="m 221.73348,553.05942 19.31149,-25.58133 0.0167,51.09625 z"
+             d="m 221.73348,557.05942 19.31149,-18.45207 0.0167,36.84587 z"
              inkscape:label="tip1" />
           <text
              xml:space="preserve"
              id="arrow1_zaehlwert_text"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.7555554px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:end;writing-mode:rl-tb;direction:rtl;white-space:pre;display:inline;fill:#000000;fill-opacity:1;stroke-width:43.9482"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.7556px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:end;writing-mode:rl-tb;direction:rtl;white-space:pre;display:inline;fill:#000000;fill-opacity:1;stroke-width:43.9482"
              x="215.24681"
-             y="562.0257"
+             y="563.9740875"
              inkscape:label="zaehlwertArrowOne"><tspan
                sodipodi:role="line"
-               id="arrow1_zaehlwert_tspan">123456</tspan></text>
+               id="arrow1_zaehlwert_tspan"
+               x="215.24681"
+               y="563.9740875">123456</tspan></text>
         </g>
         <g
            id="arrow2">
           <path
              style="fill:#000000;stroke-width:40.1708"
-             d="m 245.31124,623 v -28 h 909.68866 v 27.997 z"
+             d="m 245.31124 623 v -20 h 909.68866 v 20 z"
              id="arrow2_shaft"
              inkscape:label="shaft2" />
           <path
              style="fill:none;stroke:#000000;stroke-width:1.75545;stroke-dasharray:none;stroke-opacity:1"
              id="arrow2_tip"
-             d="m 1178.1206,609.06771 -18.7975,-22.45207 -0.017,44.84587 z"
+             d="m 1178.1206,613.06771 -19.31149,-18.45207 -0.0169,36.84587 z"
              inkscape:label="tip2" />
           <text
              xml:space="preserve"
              id="arrow2_zaehlwert_text"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.7555554px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:end;writing-mode:rl-tb;direction:rtl;white-space:pre;display:inline;fill:#000000;fill-opacity:1;stroke-width:43.9482"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.7556px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:end;writing-mode:rl-tb;direction:rtl;white-space:pre;display:inline;fill:#000000;fill-opacity:1;stroke-width:43.9482"
              x="215.83165"
-             y="615.81903"
+             y="619.9740821"
              inkscape:label="zaehlwertArrowTwo"><tspan
                sodipodi:role="line"
-               id="arrow2_zaehlwert_tspan">123456</tspan></text>
+               id="arrow2_zaehlwert_tspan"
+               x="215.83165"
+               y="619.9740821">123456</tspan></text>
         </g>
         <path
            style="fill:#000000;fill-opacity:1;stroke-width:3.26332;stroke-dasharray:none"
-           d="m 133.56306,621.30263 h 80.44096 v 1.0263 h -80.44096 z"
+           d="m 133.56306 626.49999522 h 80.44096 v 1.0263 h -80.44096 z"
            id="arrows_1_and_2_sum_line"
            inkscape:label="separatorOneTwo" />
         <text
            xml:space="preserve"
            id="arrows_1_and_2_sum_text"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7555554px;font-family:Arial;-inkscape-font-specification:'Arial Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:end;writing-mode:rl-tb;direction:rtl;white-space:pre;display:inline;fill:#000000;fill-opacity:1;stroke-width:43.9644"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7556px;font-family:Arial;-inkscape-font-specification:'Arial Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:end;writing-mode:rl-tb;direction:rtl;white-space:pre;display:inline;fill:#000000;fill-opacity:1;stroke-width:43.9644"
            x="215.26794"
-           y="642.70013"
+           y="647.6993291"
            inkscape:label="sumArrowsOneTwo"><tspan
              sodipodi:role="line"
-             id="arrows_1_and_2_sum_tspan">123456</tspan></text>
+             id="arrows_1_and_2_sum_tspan"
+             x="215.26794"
+             y="647.6993291">123456</tspan></text>
       </g>
       <g
          id="arrows_3_and_4">
@@ -312,66 +318,66 @@
            id="arrow3">
           <path
              style="fill:#000000;stroke-width:40.1798"
-             d="m 245,804.99999 v -28 h 910.1007 v 27.997 z"
+             d="m 245 804.99999 v -20 h 910.1007 v 20 z"
              id="arrow3_shaft"
              inkscape:label="shaft3" />
           <path
              style="fill:none;stroke:#000000;stroke-width:1.7698;stroke-dasharray:none;stroke-opacity:1"
              id="arrow3_tip"
-             d="m 221.49329,791.09394 19.39305,-22.32164 0.0169,44.58532 z"
+             d="m 221.49329,795.09394 19.31149,-18.45207 0.0169,36.84587 z"
              inkscape:label="tip3" />
           <text
              xml:space="preserve"
              id="arrow3_zaehlwert_text"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.7555554px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:end;writing-mode:rl-tb;direction:rtl;white-space:pre;display:inline;fill:#000000;fill-opacity:1;stroke-width:43.9482"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.7556px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:end;writing-mode:rl-tb;direction:rtl;white-space:pre;display:inline;fill:#000000;fill-opacity:1;stroke-width:43.9482"
              x="1274.4691"
-             y="799.2951"
+             y="801.974045"
              inkscape:label="zaehlwertArrowThree"><tspan
                sodipodi:role="line"
                id="arrow3_zaehlwert_tspan"
                x="1274.4691"
-               y="799.2951">123456</tspan></text>
+               y="801.974045">123456</tspan></text>
         </g>
         <g
            id="arrow4">
           <path
              style="fill:#000000;stroke-width:40.1798"
-             d="m 244.89933,860.99999 v -28 H 1155 v 27.997 z"
+             d="m 244.89933 860.99999 v -20 H 1155 v 20 z"
              id="arrow4_shaft"
              inkscape:label="shaft4" />
           <path
              style="fill:none;stroke:#000000;stroke-width:1.75413;stroke-dasharray:none;stroke-opacity:1"
              id="arrow4_tip"
-             d="m 1178.1774,846.90543 -18.6954,-22.33904 -0.017,44.62008 z"
+             d="m 1178.1774,850.90543 -19.31149,-18.45207 -0.0169,36.84587 z"
              inkscape:label="tip4" />
           <text
              xml:space="preserve"
              id="arrow4_zaehlwert_text"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.7555554px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:end;writing-mode:rl-tb;direction:rtl;white-space:pre;display:inline;fill:#000000;fill-opacity:1;stroke-width:43.9482"
-             x="1273.3658"
-             y="855.68152"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.7556px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:end;writing-mode:rl-tb;direction:rtl;white-space:pre;display:inline;fill:#000000;fill-opacity:1;stroke-width:43.9482"
+             x="1274.4691"
+             y="857.974051"
              inkscape:label="zaehlwertArrowFour"><tspan
                sodipodi:role="line"
                id="arrow4_zaehlwert_tspan"
-               x="1273.3658"
-               y="855.68152">123456</tspan></text>
+               x="1274.4691"
+               y="857.974051">123456</tspan></text>
         </g>
         <path
            style="fill:#000000;fill-opacity:1;stroke-width:13.4005"
-           d="m 1186.6029,862.50248 h 87.5595 v 0.55173 h -87.5595 z"
+           d="m 1186.6029,864.49999 h 87.5595 v 1.0263 h -87.5595 z"
            id="arrows_3_and_4_sum_line"
            inkscape:label="separatorThreeFour" />
         <text
            xml:space="preserve"
            id="arrows_3_and_4_sum_text"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7555554px;font-family:Arial;-inkscape-font-specification:'Arial Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:end;writing-mode:rl-tb;direction:rtl;white-space:pre;display:inline;fill:#000000;fill-opacity:1;stroke-width:43.9644"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7556px;font-family:Arial;-inkscape-font-specification:'Arial Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:end;writing-mode:rl-tb;direction:rtl;white-space:pre;display:inline;fill:#000000;fill-opacity:1;stroke-width:43.9644"
            x="1274.8474"
-           y="884.09052"
+           y="885.69933"
            inkscape:label="sumArrowsThreeFour"><tspan
              sodipodi:role="line"
              id="arrows_3_and_4_sum_tspan"
              x="1274.8474"
-             y="884.09052">123456</tspan></text>
+             y="885.69933">123456</tspan></text>
       </g>
     </g>
     <text

--- a/svg/qjs_belastungsplan_plain.svg
+++ b/svg/qjs_belastungsplan_plain.svg
@@ -187,55 +187,55 @@
            id="arrow1">
           <path
              style="fill:#000000;stroke-width:40.1656"
-             d="m 245,567 v -28 h 909.4546 v 27.998 z"
+             d="m 245,567 v -20 h 909.4546 v 20 z"
              id="arrow1_shaft" />
           <path
-             style="fill:none;stroke:#000000;stroke-width:2.08902;stroke-dasharray:none;stroke-opacity:1"
+             style="fill:none;stroke:#000000;stroke-width:1.75545;stroke-dasharray:none;stroke-opacity:1"
              id="arrow1_tip"
-             d="m 221.73348,553.05942 19.31149,-25.58133 0.0167,51.09625 z" />
+             d="m 221.73348,557.05942 19.31149,-18.45207 0.0167,36.84587 z" />
           <text
              xml:space="preserve"
              id="arrow1_zaehlwert_text"
              style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.7556px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:end;writing-mode:rl-tb;direction:rtl;white-space:pre;display:inline;fill:#000000;fill-opacity:1;stroke-width:43.9482"
              x="215.24681"
-             y="562.0257"><tspan
+             y="563.97406"><tspan
                id="arrow1_zaehlwert_tspan"
                x="215.24681"
-               y="562.0257">123456</tspan></text>
+               y="563.97406">123456</tspan></text>
         </g>
         <g
            id="arrow2">
           <path
              style="fill:#000000;stroke-width:40.1708"
-             d="m 245.31124,623 v -28 h 909.68866 v 27.997 z"
+             d="m 245.31124,623 v -20 h 909.68866 v 20 z"
              id="arrow2_shaft" />
           <path
              style="fill:none;stroke:#000000;stroke-width:1.75545;stroke-dasharray:none;stroke-opacity:1"
              id="arrow2_tip"
-             d="m 1178.1206,609.06771 -18.7975,-22.45207 -0.017,44.84587 z" />
+             d="m 1178.1206,613.06771 -19.3115,-18.45207 -0.017,36.84587 z" />
           <text
              xml:space="preserve"
              id="arrow2_zaehlwert_text"
              style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.7556px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:end;writing-mode:rl-tb;direction:rtl;white-space:pre;display:inline;fill:#000000;fill-opacity:1;stroke-width:43.9482"
              x="215.83165"
-             y="615.81903"><tspan
+             y="619.97406"><tspan
                id="arrow2_zaehlwert_tspan"
                x="215.83165"
-               y="615.81903">123456</tspan></text>
+               y="619.97406">123456</tspan></text>
         </g>
         <path
            style="fill:#000000;fill-opacity:1;stroke-width:3.26332;stroke-dasharray:none"
-           d="m 133.56306,621.30263 h 80.44096 v 1.0263 h -80.44096 z"
+           d="m 133.56306,626.5 h 80.44096 v 1.0263 h -80.44096 z"
            id="arrows_1_and_2_sum_line" />
         <text
            xml:space="preserve"
            id="arrows_1_and_2_sum_text"
            style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7556px;font-family:Arial;-inkscape-font-specification:'Arial Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:end;writing-mode:rl-tb;direction:rtl;white-space:pre;display:inline;fill:#000000;fill-opacity:1;stroke-width:43.9644"
            x="215.26794"
-           y="642.70013"><tspan
+           y="647.69934"><tspan
              id="arrows_1_and_2_sum_tspan"
              x="215.26794"
-             y="642.70013">123456</tspan></text>
+             y="647.69934">123456</tspan></text>
       </g>
       <g
          id="arrows_3_and_4">
@@ -243,55 +243,55 @@
            id="arrow3">
           <path
              style="fill:#000000;stroke-width:40.1798"
-             d="m 245,804.99999 v -28 h 910.1007 v 27.997 z"
+             d="m 245,804.99999 v -20 h 910.1007 v 20 z"
              id="arrow3_shaft" />
           <path
              style="fill:none;stroke:#000000;stroke-width:1.7698;stroke-dasharray:none;stroke-opacity:1"
              id="arrow3_tip"
-             d="m 221.49329,791.09394 19.39305,-22.32164 0.0169,44.58532 z" />
+             d="m 221.49329,795.09394 19.31149,-18.45207 0.0169,36.84587 z" />
           <text
              xml:space="preserve"
              id="arrow3_zaehlwert_text"
              style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.7556px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:end;writing-mode:rl-tb;direction:rtl;white-space:pre;display:inline;fill:#000000;fill-opacity:1;stroke-width:43.9482"
              x="1274.4691"
-             y="799.2951"><tspan
+             y="801.97406"><tspan
                id="arrow3_zaehlwert_tspan"
                x="1274.4691"
-               y="799.2951">123456</tspan></text>
+               y="801.97406">123456</tspan></text>
         </g>
         <g
            id="arrow4">
           <path
              style="fill:#000000;stroke-width:40.1798"
-             d="m 244.89933,860.99999 v -28 H 1155 v 27.997 z"
+             d="m 244.89933,860.99999 v -20 H 1155 v 20 z"
              id="arrow4_shaft" />
           <path
              style="fill:none;stroke:#000000;stroke-width:1.75413;stroke-dasharray:none;stroke-opacity:1"
              id="arrow4_tip"
-             d="m 1178.1774,846.90543 -18.6954,-22.33904 -0.017,44.62008 z" />
+             d="m 1178.1774,850.90543 -19.3115,-18.45207 -0.017,36.84587 z" />
           <text
              xml:space="preserve"
              id="arrow4_zaehlwert_text"
              style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.7556px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:end;writing-mode:rl-tb;direction:rtl;white-space:pre;display:inline;fill:#000000;fill-opacity:1;stroke-width:43.9482"
-             x="1273.3658"
-             y="855.68152"><tspan
+             x="1274.4691"
+             y="857.97406"><tspan
                id="arrow4_zaehlwert_tspan"
-               x="1273.3658"
-               y="855.68152">123456</tspan></text>
+               x="1274.4691"
+               y="857.97406">123456</tspan></text>
         </g>
         <path
            style="fill:#000000;fill-opacity:1;stroke-width:13.4005"
-           d="m 1186.6029,862.50248 h 87.5595 v 0.55173 h -87.5595 z"
+           d="m 1186.6029,864.49999 h 87.5595 v 1.0263 h -87.5595 z"
            id="arrows_3_and_4_sum_line" />
         <text
            xml:space="preserve"
            id="arrows_3_and_4_sum_text"
            style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.7556px;font-family:Arial;-inkscape-font-specification:'Arial Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:end;writing-mode:rl-tb;direction:rtl;white-space:pre;display:inline;fill:#000000;fill-opacity:1;stroke-width:43.9644"
            x="1274.8474"
-           y="884.09052"><tspan
+           y="885.69934"><tspan
              id="arrows_3_and_4_sum_tspan"
              x="1274.8474"
-             y="884.09052">123456</tspan></text>
+             y="885.69934">123456</tspan></text>
       </g>
     </g>
     <text


### PR DESCRIPTION
# Description

- Set maximum width of arrows (belastungsbänder) to width of arrows of zaehlart Q
- Adjust position of arrow tips and zaehlwert numbers to match with center of arrows

# Issue References

FV-486
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)